### PR TITLE
Update: ScrollButton Props for improved Customizability

### DIFF
--- a/src/src/components/ScrollButton/ScrollButton.tsx
+++ b/src/src/components/ScrollButton/ScrollButton.tsx
@@ -1,28 +1,31 @@
+import * as React from "react";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faArrowCircleDown} from "@fortawesome/free-solid-svg-icons";
-import * as React from "react";
+import {IconProp} from "@fortawesome/fontawesome-svg-core";
 import {motion} from "framer-motion";
 
 import "./ScrollButton.scss";
 
 interface ScrollButtonProps {
     scrollRef: React.RefObject<any>;
-    icon?: React.ReactNode;
+    icon?: IconProp;
     children?: React.ReactNode;
+    text: string;
 }
 
 export default function ScrollButton(props: ScrollButtonProps) {
     const scrollToRef = (ref: React.RefObject<HTMLDivElement>) => window.scrollTo(0, ref.current!!.offsetTop);
 
-    const {scrollRef, icon, children} = props;
+    const {scrollRef, icon, text, children} = props;
 
     return (
         <div style={{padding: '2px'}}>
             <motion.button onClick={() => scrollToRef(scrollRef)} className="scroll-button" whileHover={{scale: 1.1}}
                            whileTap={{scale: 0.9}}>
-                {icon || <FontAwesomeIcon icon={faArrowCircleDown} style={{height: '55px', width: '55px'}}/>}
+                {children || icon ? <FontAwesomeIcon icon={icon!!} style={{height: '55px', width: '55px'}}/> :
+                    <FontAwesomeIcon icon={faArrowCircleDown} style={{height: '55px', width: '55px'}}/>}
             </motion.button>
-            <div style={{fontSize: '24px', padding: '2px'}}>{children || "Runterscrollen"}</div>
+            {!children ? <div style={{fontSize: '24px', padding: '2px'}}>{text || "Runterscrollen"}</div> : null}
         </div>
     );
 }

--- a/src/src/components/ScrollButton/ScrollButton.tsx
+++ b/src/src/components/ScrollButton/ScrollButton.tsx
@@ -10,7 +10,7 @@ interface ScrollButtonProps {
     scrollRef: React.RefObject<any>;
     icon?: IconProp;
     children?: React.ReactNode;
-    text: string;
+    text: React.ReactNode;
 }
 
 export default function ScrollButton(props: ScrollButtonProps) {


### PR DESCRIPTION
 - Add `text` prop to ScrollButton for basic level customization. 
 - Change `icon` prop to type of `IconProps` for basic level customization.
 - Change `children` prop to replace all button contents if given.