### PR TITLE
Fix: Make Text Prop Optional

### DIFF
--- a/src/src/components/ScrollButton/ScrollButton.tsx
+++ b/src/src/components/ScrollButton/ScrollButton.tsx
@@ -10,7 +10,7 @@ interface ScrollButtonProps {
     scrollRef: React.RefObject<any>;
     icon?: IconProp;
     children?: React.ReactNode;
-    text: React.ReactNode;
+    text?: React.ReactNode;
 }
 
 export default function ScrollButton(props: ScrollButtonProps) {


### PR DESCRIPTION
Made `text` prop in ScrollButton optional to make use of default value.