### PR TITLE
Update: Decrease Mobile Banner Text Size for Improved Readability

### DIFF
--- a/src/src/components/Banner/Banner.scss
+++ b/src/src/components/Banner/Banner.scss
@@ -13,6 +13,10 @@
 
     h2 {
       font-size: 4em;
+
+      @media (max-width: 768px) {
+        font-size: 2em;
+      }
     }
   }
 }

--- a/src/src/components/Banner/Banner.scss
+++ b/src/src/components/Banner/Banner.scss
@@ -15,7 +15,7 @@
       font-size: 4em;
 
       @media (max-width: 768px) {
-        font-size: 2em;
+        font-size: 2.5em;
       }
     }
   }


### PR DESCRIPTION
Decrease text size of `h2` in banners on mobile devices (max-width: 768px) to 2.5em for improved readability.