### PR TITLE
Update: Remove Border from ScrollButton

### DIFF
--- a/src/src/components/ScrollButton/ScrollButton.scss
+++ b/src/src/components/ScrollButton/ScrollButton.scss
@@ -6,6 +6,8 @@
   @extend .btn-outline-dark;
 
   background: none;
+  outline: none;
+  border: none;
 
   &:hover {
     background: none !important;


### PR DESCRIPTION
Removed borders and outlines from button used to create ScrollButton to go with flat theme and create focus on icon.