### PR TITLE
Feature: Update Structure for easy Customization

### DIFF
--- a/src/src/components/ScrollButton/ScrollButton.scss
+++ b/src/src/components/ScrollButton/ScrollButton.scss
@@ -1,20 +1,22 @@
 @import "~bootstrap/scss/bootstrap";
 
 .scroll-button {
-  @extend .scroll-button;
-  @extend .btn;
-  @extend .btn-outline-dark;
+  button {
+    @extend .scroll-button;
+    @extend .btn;
+    @extend .btn-outline-dark;
 
-  background: none;
-  outline: none;
-  border: none;
+    background: none;
+    outline: none;
+    border: none;
 
-  &:hover {
-    background: none !important;
-    color: #343a40 !important;
-
-    svg {
+    &:hover {
+      background: none;
       color: #343a40;
+
+      svg {
+        color: #343a40;
+      }
     }
   }
 }

--- a/src/src/components/ScrollButton/ScrollButton.tsx
+++ b/src/src/components/ScrollButton/ScrollButton.tsx
@@ -19,8 +19,8 @@ export default function ScrollButton(props: ScrollButtonProps) {
     const {scrollRef, icon, text, children} = props;
 
     return (
-        <div style={{padding: '2px'}}>
-            <motion.button onClick={() => scrollToRef(scrollRef)} className="scroll-button" whileHover={{scale: 1.1}}
+        <div style={{padding: '2px'}} className="scroll-button">
+            <motion.button onClick={() => scrollToRef(scrollRef)} whileHover={{scale: 1.1}}
                            whileTap={{scale: 0.9}}>
                 {children || icon ? <FontAwesomeIcon icon={icon!!} style={{height: '55px', width: '55px'}}/> :
                     <FontAwesomeIcon icon={faArrowCircleDown} style={{height: '55px', width: '55px'}}/>}


### PR DESCRIPTION
Set the class of ScrollButton to `scroll-button` and using specific SCSS overrides to control the button. This allows for easier customization when using the scroll-button on custom pages.