### PR TITLE
Component: Generic Slideshow

### DIFF
--- a/src/src/components/Slideshow/Slideshow.scss
+++ b/src/src/components/Slideshow/Slideshow.scss
@@ -1,0 +1,19 @@
+.slideshow {
+  background: #535353;
+
+  .carousel-inner {
+    .carousel-item {
+      & > div:first-of-type {
+        position: relative;
+        min-height: 100vh;
+
+        img {
+          position: absolute;
+          top: 50%;
+          -ms-transform: translateY(-50%);
+          transform: translateY(-50%);
+        }
+      }
+    }
+  }
+}

--- a/src/src/components/Slideshow/Slideshow.tsx
+++ b/src/src/components/Slideshow/Slideshow.tsx
@@ -1,0 +1,30 @@
+import {Carousel} from "react-bootstrap";
+import * as React from "react";
+
+interface SlideshowProps {
+    images: { path: string, title: string, sub: string }[];
+    shuffle?: boolean;
+}
+
+export default function Slideshow(props: SlideshowProps) {
+    const {images, shuffle} = props;
+
+    return (
+        <Carousel className="slideshow">
+            {(shuffle ? images.shuffle() : images).map((img, i) =>
+                <Carousel.Item key={i}>
+                    <div>
+                        <img
+                            className="d-block w-100"
+                            src={`./res/img/mguignard/frankfurt/${img.path}`}
+                            alt={img.sub}
+                        />
+                    </div>
+                    <Carousel.Caption>
+                        <h3>{img.title}</h3>
+                        <p>{img.sub}</p>
+                    </Carousel.Caption>
+                </Carousel.Item>)}
+        </Carousel>
+    );
+}


### PR DESCRIPTION
Adds a generic slideshow component that takes two props: `images` and `shuffle`

Can be inserted into the code as such:
```html
<Slideshow images={images} shuffle/>
```

The images are displayed in a Bootstrap carousel with some custom styling for a full size experience and a dark background.