### PR TITLE
Fix: Path Prop in Slideshow Component

### DIFF
--- a/src/src/components/Slideshow/Slideshow.tsx
+++ b/src/src/components/Slideshow/Slideshow.tsx
@@ -16,7 +16,7 @@ export default function Slideshow(props: SlideshowProps) {
                     <div>
                         <img
                             className="d-block w-100"
-                            src={`./res/img/mguignard/frankfurt/${img.path}`}
+                            src={img.path}
                             alt={img.sub}
                         />
                     </div>


### PR DESCRIPTION
This removes the residue path from earlier usage in the `Slideshow` component to allow for generic paths.