### PR TITLE
CLI: inputColor and onRun Properties

### DIFF
--- a/src/src/components/CommandLineInterface/PowerShell/PowerShell.tsx
+++ b/src/src/components/CommandLineInterface/PowerShell/PowerShell.tsx
@@ -6,7 +6,7 @@ import "./PowerShell.scss";
 export default function PowerShell(props: CommandLineInterfaceProps){
     return (
         <div className="powershell">
-            <CommandLineInterface {...props}/>
+            <CommandLineInterface {...props} inputColor="yellow"/>
         </div>
     )
 }


### PR DESCRIPTION
 - Add inputColor property for user inputs and used in PowerShell ISE.
 - Replace output/callback with onRun which can be a function returning `CLILine[]` or simply a `CLILine` array.
 - Add support for arrow-up to grab previous inputs which are saved in the state.