### PR TITLE
Bash Component: Simplified Props

### DIFF
--- a/src/src/components/CommandLineInterface/Bash/Bash.tsx
+++ b/src/src/components/CommandLineInterface/Bash/Bash.tsx
@@ -1,12 +1,30 @@
 import * as React from "react";
-import CommandLineInterface, {CommandLineInterfaceProps} from "../CommandLineInterface";
+import CommandLineInterface, {CLIString, CommandLineInterfaceProps} from "../CommandLineInterface";
 
 import "./Bash.scss";
 
-export default function Bash(props: CommandLineInterfaceProps){
+interface BashProps extends CommandLineInterfaceProps {
+    username: string;
+    pcName: string;
+}
+
+export default function Bash(props: Partial<BashProps>) {
+    const {username, pcName} = props;
+
     return (
         <div className="bash">
-            <CommandLineInterface {...props} pathColor="#89e032"/>
+            <CommandLineInterface commandlets={props.commandlets || []} {...props} pathColor="#89e032" path={[{
+                value: `${username}@${pcName}`
+            }, {
+                value: ":",
+                color: "white"
+            }, {
+                value: "~",
+                color: "#719ecd"
+            }, {
+                value: "$ ",
+                color: "white"
+            }]}/>
         </div>
     )
 }

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -9,13 +9,13 @@ export interface Commandlet {
     commandlets?: Commandlet[];
 }
 
-interface CLIString {
+export interface CLIString {
     value: string;
     readonly?: boolean;
     color?: string;
 }
 
-interface CLILine {
+export interface CLILine {
     strings: CLIString[];
     color?: string;
     fontSize?: number;


### PR DESCRIPTION
 - Add `username` and `pcName` props to `Bash` component for automatic creation of `path` with generic Bash colors.
 - Export CLI Interfaces for use in separate components.