### PR TITLE
CLI: Insert invisible Textarea for use on Mobile Devices

### DIFF
--- a/src/src/components/CommandLineInterface/CommandLineInterface.scss
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.scss
@@ -1,10 +1,30 @@
-.cli {
+.cli-container {
   height: 100vh;
   width: 100vw;
-  overflow-y: scroll;
-  overflow-wrap: anywhere;
-  overflow-x: scroll;
-  background: black;
-  color: white;
-  font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
+  position: relative;
+
+  .cli, .input {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  .input {
+    resize: none;
+  }
+
+  .cli {
+    pointer-events: none;
+    z-index: 3;
+    overflow-y: scroll;
+    overflow-wrap: anywhere;
+    overflow-x: scroll;
+    background: black;
+    color: white;
+    font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
+  }
 }

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -183,15 +183,17 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
             case "c":
                 if (this.state.controlDown) {
                     this.writeLine({strings: [{value: " ^C"}]}, this.emptyLine);
+                    event.preventDefault();
                 }
-                event.preventDefault();
                 break;
             case "Insert":
-                navigator.clipboard.readText()
-                    .then(text => {
-                        this.writeLine({strings: [{value: text}]});
-                    });
-                event.preventDefault();
+                if (this.state.shiftDown) {
+                    navigator.clipboard.readText()
+                        .then(text => {
+                            this.writeLine({strings: [{value: text}]});
+                        });
+                    event.preventDefault();
+                }
                 break;
         }
     };


### PR DESCRIPTION
Added an invisible textarea in front of the CLI with all the listeners to enable support for mobile devices. Also prevents default behavior of certain keys (arrowUp, enter, shift etc.) to block error paths.