### PR TITLE
Shuffle Frankfurt Slideshow

### DIFF
--- a/src/src/components/Slideshow/Frankfurt/FrankfurtSlideshow.tsx
+++ b/src/src/components/Slideshow/Frankfurt/FrankfurtSlideshow.tsx
@@ -87,6 +87,10 @@ export default function FrankfurtSlideshow(props: FrankfurtSlideshowProps) {
     const {english} = props;
 
     return (
-        <Slideshow images={images.map(i => ({path: "./res/img/frankfurt/" + i.filename, title: english ? i.titleEnglish || i.title : i.title, sub: i.sub}))}/>
+        <Slideshow shuffle images={images.map(i => ({
+            path: "./res/img/frankfurt/" + i.filename,
+            title: english ? i.titleEnglish || i.title : i.title,
+            sub: i.sub
+        }))}/>
     );
 }


### PR DESCRIPTION
Enabled the `shuffle` option for the `Slideshow` component in the Frankfurt slideshow and format code.