### PR TITLE
CLI: Fix Scroll, Arrow Up/Down and Backspace

### DIFF
--- a/src/src/components/CommandLineInterface/CommandLineInterface.scss
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.scss
@@ -18,7 +18,6 @@
   }
 
   .cli {
-    pointer-events: none;
     z-index: 3;
     overflow-y: scroll;
     overflow-wrap: anywhere;

--- a/src/src/components/CommandLineInterface/CommandLineInterface.scss
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.scss
@@ -18,6 +18,7 @@
   }
 
   .cli {
+    pointer-events: none;
     z-index: 3;
     overflow-y: scroll;
     overflow-wrap: anywhere;

--- a/src/src/components/CommandLineInterface/CommandLineInterface.scss
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.scss
@@ -1,10 +1,30 @@
-.cli {
+.cli-container {
   height: 100vh;
   width: 100vw;
-  overflow-y: scroll;
-  overflow-wrap: anywhere;
-  overflow-x: scroll;
-  background: black;
-  color: white;
-  font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
+  position: relative;
+
+  .cli, .input {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  .input {
+    resize: none;
+  }
+
+  .cli {
+    pointer-events: none;
+    z-index: 3;
+    overflow-y: scroll;
+    overflow-wrap: anywhere;
+    overflow-x: scroll;
+    background: black;
+    color: white;
+    font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
+  }
 }

--- a/src/src/components/CommandLineInterface/CommandLineInterface.scss
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.scss
@@ -1,30 +1,10 @@
-.cli-container {
+.cli {
   height: 100vh;
   width: 100vw;
-  position: relative;
-
-  .cli, .input {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-    height: 100%;
-    width: 100%;
-  }
-
-  .input {
-    resize: none;
-  }
-
-  .cli {
-    pointer-events: none;
-    z-index: 3;
-    overflow-y: scroll;
-    overflow-wrap: anywhere;
-    overflow-x: scroll;
-    background: black;
-    color: white;
-    font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
-  }
+  overflow-y: scroll;
+  overflow-wrap: anywhere;
+  overflow-x: scroll;
+  background: black;
+  color: white;
+  font-family: Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace;
 }

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import "./CommandLineInterface.scss";
-import {ChangeEvent} from "react";
 
 export interface Commandlet {
     command: RegExp;
@@ -39,7 +38,6 @@ interface CommandLineInterfaceState {
     commandlets: Commandlet[];
     inputs: string[];
     inputIndex?: number;
-    content: string;
 }
 
 export default class CommandLineInterface extends React.Component<CommandLineInterfaceProps, CommandLineInterfaceState> {
@@ -56,8 +54,7 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
             controlDown: false,
             shiftDown: false,
             commandlets: this.props.commandlets,
-            inputs: [],
-            content: ""
+            inputs: []
         };
 
         this.handleKeyDown = this.handleKeyDown.bind(this);

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -183,15 +183,17 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
             case "c":
                 if (this.state.controlDown) {
                     this.writeLine({strings: [{value: " ^C"}]}, this.emptyLine);
+                    event.preventDefault();
                 }
-                event.preventDefault();
                 break;
             case "Insert":
-                navigator.clipboard.readText()
-                    .then(text => {
-                        this.writeLine({strings: [{value: text}]});
-                    });
-                event.preventDefault();
+                if (this.state.shiftDown) {
+                    navigator.clipboard.readText()
+                        .then(text => {
+                            this.writeLine({strings: [{value: text}]});
+                        });
+                    event.preventDefault();
+                }
                 break;
         }
     };

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -195,6 +195,19 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
                     event.preventDefault();
                 }
                 break;
+            case "Backspace":
+                let newLines: CLILine[] = Object.assign([], this.state.lines);
+                let strings = newLines[newLines.length - 1].strings;
+                let lastString = strings[strings.length - 1];
+
+                if (!lastString.readonly) {
+                    lastString.value = lastString.value.substring(0, lastString.value.length - 1);
+                    if (lastString.value.length === 0) strings.pop();
+                    newLines[newLines.length - 1].strings = strings;
+                    this.setState({lines: newLines});
+                }
+                event.preventDefault();
+                break;
         }
     };
 
@@ -212,19 +225,6 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
         if (text.length > this.state.content.length) {
             this.writeLine({strings: [{value: text[text.length - 1], color: this.props.inputColor || "inherit"}]});
             this.setState({content: text});
-        } else {
-            let newLines: CLILine[] = Object.assign([], this.state.lines);
-            let strings = newLines[newLines.length - 1].strings;
-            let lastString = strings[strings.length - 1];
-
-            if (!lastString.readonly) {
-                lastString.value = lastString.value.substring(0, lastString.value.length - 1);
-                if (lastString.value.length === 0) strings.pop();
-                newLines[newLines.length - 1].strings = strings;
-                this.setState({lines: newLines, content: text});
-            } else {
-                event.preventDefault();
-            }
         }
     }
 

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -94,7 +94,7 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
         for (let i = 0; i < lines.length; i++) {
             let line = lines[i];
 
-            let newLine = i == 0 ? {
+            let newLine = i === 0 ? {
                 strings: lastLine.strings.concat(line.strings as any),
                 color: lastLine.color,
                 fontSize: lastLine.fontSize
@@ -104,7 +104,7 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
                 fontSize: line?.fontSize
             };
 
-            if (i == 0) newLines.pop();
+            if (i === 0) newLines.pop();
             newLines.push(newLine);
         }
 

--- a/src/src/components/CommandLineInterface/CommandLineInterface.tsx
+++ b/src/src/components/CommandLineInterface/CommandLineInterface.tsx
@@ -38,6 +38,7 @@ interface CommandLineInterfaceState {
     shiftDown: boolean;
     commandlets: Commandlet[];
     inputs: string[];
+    inputIndex?: number;
     content: string;
 }
 
@@ -121,7 +122,8 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
 
         let newInputs = Object.assign([], this.state.inputs);
         newInputs.push(input);
-        this.setState({inputs: newInputs});
+        console.log(newInputs);
+        this.setState({inputs: newInputs, inputIndex: undefined});
 
         for (let i = 0; i < commandlets.length; i++) {
             let result = commandlets[i].command.exec(input);
@@ -171,12 +173,31 @@ export default class CommandLineInterface extends React.Component<CommandLineInt
                 break;
             case "ArrowUp":
                 if (this.state.inputs.length > 0) {
-                    this.writeLine({
-                        strings: [{
-                            value: this.state.inputs[this.state.inputs.length - 1],
-                            color: this.props.inputColor || "inherit"
-                        }]
-                    });
+                    let newInputIndex = this.state.inputIndex ? Math.max(0, this.state.inputIndex - 1) : this.state.inputs.length - 1;
+                    let newLines: CLILine[] = Object.assign([], this.state.lines);
+                    let strings = newLines[newLines.length - 1].strings;
+                    if (this.state.inputIndex !== undefined) {
+                        strings[strings.length - 1].value = this.state.inputs[newInputIndex];
+                    } else {
+                        strings.push({value: this.state.inputs[newInputIndex], color: this.props.inputColor || "inherit"});
+                    }
+                    newLines[newLines.length - 1].strings = strings;
+                    this.setState({lines: newLines, inputIndex: newInputIndex});
+                }
+                event.preventDefault();
+                break;
+            case "ArrowDown":
+                if (this.state.inputs.length > 0) {
+                    let newInputIndex = this.state.inputIndex !== undefined && this.state.inputIndex < this.state.inputs.length - 1 ? Math.min(this.state.inputs.length - 1, this.state.inputIndex + 1) : 0;
+                    let newLines: CLILine[] = Object.assign([], this.state.lines);
+                    let strings = newLines[newLines.length - 1].strings;
+                    if (this.state.inputIndex !== undefined) {
+                        strings[strings.length - 1].value = this.state.inputs[newInputIndex];
+                    } else {
+                        strings.push({value: this.state.inputs[newInputIndex], color: this.props.inputColor || "inherit"});
+                    }
+                    newLines[newLines.length - 1].strings = strings;
+                    this.setState({lines: newLines, inputIndex: newInputIndex});
                 }
                 event.preventDefault();
                 break;


### PR DESCRIPTION
Overhauled CLI component to fix previous changes caused by using an overlaying `<textarea>` for mobile supporting.

Now using a `<div>` again with attributes similar to match a `<textarea>` and enable mobile support, with additional handling of key events to manage inputs.

Add support for arrow up/down by storing previous inputs in a list and iterating through them with the keys. Enter resets the state of `inputIndex` to `undefined` to start afresh. 